### PR TITLE
Add pip-tools option + validation enhancements

### DIFF
--- a/ppieces/main.py
+++ b/ppieces/main.py
@@ -7,6 +7,7 @@ from termcolor import colored
 
 from ppieces import __version__
 from ppieces.utils.cli import run_cli
+from ppieces.utils.validation import validate_options
 
 
 @click.command()
@@ -18,7 +19,7 @@ from ppieces.utils.cli import run_cli
     help="Run the script in non-interactive mode.",
 )
 @click.option(
-    "-p",
+    "-f",
     "--project-folder",
     type=click.Path(exists=True),
     required=False,
@@ -44,7 +45,7 @@ from ppieces.utils.cli import run_cli
     help="Initialize a git repository (with .gitignore and README files)",
 )
 @click.option(
-    "-pre",
+    "-c",
     "--pre-commit",
     is_flag=True,
     help="Add pre-commit configuration.",
@@ -66,6 +67,12 @@ from ppieces.utils.cli import run_cli
     "--makefile",
     is_flag=True,
     help="Add a default Makefile.",
+)
+@click.option(
+    "-p",
+    "--pip-tools",
+    is_flag=True,
+    help="Add a default pip-tools setups.",
 )
 @click.option(
     "-u",
@@ -90,6 +97,7 @@ def main(
     ruff,
     autoenv,
     makefile,
+    pip_tools,
     username,
     version,
 ):
@@ -97,15 +105,26 @@ def main(
         click.echo(__version__)
         sys.exit(1)
 
-    if non_interactive and (not project_name or not project_folder):
-        msg = colored(
-            "\nBoth project name and project folder must be provided when running in "
-            "non-interactive mode.\n",
-            "red",
-            attrs=["bold"],
+    if not validate_options(
+        non_interactive,
+        project_folder,
+        project_name,
+        virtual_env,
+        git,
+        pre_commit,
+        ruff,
+        autoenv,
+        makefile,
+        pip_tools,
+        username,
+    ):
+        click.echo(
+            colored(
+                "\nTry 'ppieces --help' for help.\n",
+                "cyan",
+                attrs=["bold"],
+            )
         )
-        print(msg)
-        click.echo(main.get_help(click.Context(main)))
         sys.exit(2)
 
     run_cli(
@@ -118,6 +137,7 @@ def main(
         ruff,
         autoenv,
         makefile,
+        pip_tools,
         username,
     )
 

--- a/ppieces/templates/.gitignore
+++ b/ppieces/templates/.gitignore
@@ -1,9 +1,10 @@
 __pycache__/
 *.py[cod]
 *.class
-.vscode
 .aider*
 .idea
+.ruff_cache
+.vscode
 *.pyo
 *.pyd
 *.pyc

--- a/ppieces/templates/Makefile
+++ b/ppieces/templates/Makefile
@@ -1,6 +1,7 @@
 PYTHON_GLOBAL = python
-PYTHON = venv/bin/python
-PIP = venv/bin/pip
+VENV = venv/bin/
+PYTHON = $(VENV)python
+PIP = $(VENV)pip
 GIT = git
 
 .PHONY: install run

--- a/ppieces/templates/pip-tools/Makefile
+++ b/ppieces/templates/pip-tools/Makefile
@@ -1,0 +1,23 @@
+
+build-requirements:
+	$(info Building requirements...)
+	@$(VENV)pip-compile requirements/base.in -o requirements/base.txt
+	@$(VENV)pip-compile requirements/development.in -o requirements/development.txt
+	@$(VENV)pip-compile requirements/production.in -o requirements/production.txt
+	@$(VENV)pip-compile requirements/test.in -o requirements/test.txt
+
+sync-base-requirements:
+	$(info Syncing base requirements...)
+	@$(VENV)pip-sync requirements/base.txt
+
+sync-dev-requirements:
+	$(info Syncing dev requirements...)
+	@$(VENV)pip-sync requirements/development.txt
+
+sync-prod-requirements:
+	$(info Syncing prod requirements...)
+	@$(VENV)pip-sync requirements/production.txt
+
+sync-test-requirements:
+	$(info Syncing test requirements...)
+	@$(VENV)pip-sync requirements/test.txt

--- a/ppieces/templates/pip-tools/requirements/base.in
+++ b/ppieces/templates/pip-tools/requirements/base.in
@@ -1,4 +1,2 @@
-icecream
 python-dotenv
 requests
-pip-tools

--- a/ppieces/templates/pip-tools/requirements/development.in
+++ b/ppieces/templates/pip-tools/requirements/development.in
@@ -1,0 +1,5 @@
+-r base.in
+
+icecream
+ipython
+pip-tools

--- a/ppieces/templates/pip-tools/requirements/production.in
+++ b/ppieces/templates/pip-tools/requirements/production.in
@@ -1,0 +1,3 @@
+-r base.in
+
+gunicorn

--- a/ppieces/templates/pip-tools/requirements/test.in
+++ b/ppieces/templates/pip-tools/requirements/test.in
@@ -1,0 +1,5 @@
+-r base.in
+
+pytest
+coverage
+coverage-badge

--- a/ppieces/utils/cli.py
+++ b/ppieces/utils/cli.py
@@ -20,6 +20,7 @@ def run_cli(
     ruff,
     autoenv,
     makefile,
+    pip_tools,
     username,
 ):
     project_path = None
@@ -34,6 +35,7 @@ def run_cli(
                 "autoenv": autoenv,
                 "ruff": ruff,
                 "pre_commit": pre_commit,
+                "pip_tools": pip_tools,
                 "makefile": makefile,
             }
 
@@ -61,6 +63,10 @@ def run_cli(
                 "pre_commit": ask_user(
                     f"Do you want to add a pre-commit config file for `{project_name}` "
                     "project?"
+                ),
+                "pip_tools": ask_user(
+                    "Do you want to add pip-tools as your dependency manager for "
+                    f"`{project_name}` project?"
                 ),
                 "makefile": ask_user(
                     f"Do you want to add a Makefile for `{project_name}` project?"

--- a/ppieces/utils/copy.py
+++ b/ppieces/utils/copy.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import shutil
 
@@ -23,8 +24,39 @@ def copy_requirements_file(project_path):
     copy_template_file("requirements.txt", project_path)
 
 
-def copy_makefile(project_path):
+def copy_makefile(project_path, pip_tools):
     copy_template_file("Makefile", project_path)
+
+    if pip_tools:
+        pip_tools_makefile_path = os.path.join(TEMPLATES_DIR, "pip-tools/Makefile")
+        with open(pip_tools_makefile_path, "r") as f:
+            pip_tools_makefile = f.read()
+        with open(os.path.join(project_path, "Makefile"), "a") as f:
+            f.write(pip_tools_makefile)
+
+    msg = colored(
+        (f"Extended Makefile with pip-tools commands in {project_path}"),
+        "yellow",
+        attrs=["bold"],
+    )
+    print(msg)
+
+
+def copy_pip_tools_requirements_files(project_path):
+    pip_tools_templates_folder_path = os.path.join(TEMPLATES_DIR, "pip-tools")
+    requirements_folder_path = os.path.join(project_path, "requirements")
+    os.makedirs(requirements_folder_path, exist_ok=False)
+
+    pattern = f"{pip_tools_templates_folder_path}/requirements/*.in"
+    for requirement_file in glob.glob(pattern):
+        shutil.copy(requirement_file, requirements_folder_path)
+
+    msg = colored(
+        (f"Created a requirements folder for pip-tools in {project_path}"),
+        "yellow",
+        attrs=["bold"],
+    )
+    print(msg)
 
 
 def copy_main_file(project_path):

--- a/ppieces/utils/flows.py
+++ b/ppieces/utils/flows.py
@@ -3,7 +3,6 @@ import os
 from termcolor import colored
 
 from ppieces.utils.commands import (
-    check_precommit,
     create_virtual_environment,
     initial_commit,
     initialize_git_repository,
@@ -59,32 +58,24 @@ def setup_project(
 
     copy_main_file(project_path)
 
+    # we need to pop the pip_tools option from the options dict
+    # because it's not a function that we can call directly
+    # pip_tools is a flag that we need to pass for the virtual_env and makefile options
+    pip_tools = options.pop("pip_tools")
+
     for option, value in options.items():
         if value:
             if option == "git":
                 options_mapping[option](project_path, username)
+            elif option == "virtual_env" or option == "makefile":
+                options_mapping[option](project_path, pip_tools)
             else:
                 options_mapping[option](project_path)
 
 
 def finalize_project(project_path, git, pre_commit):
     if pre_commit:
-        # once we know a git repo was initialized, we can install pre-commit hooks
-        if check_precommit(git):
-            install_precommit_hooks(project_path)
-
-        # otherwise, we inform the user that we can't install pre-commit hooks
-        # without a git repo
-        else:
-            msg = colored(
-                (
-                    "\n\nWARNING: pre-commit is not installed. "
-                    "Please install it manually."
-                ),
-                "red",
-                attrs=["bold"],
-            )
-            print(msg)
+        install_precommit_hooks(project_path)
 
     # this should be the last step since we are making the initial commit
     # AFTER all the template files are copied to the new project folder

--- a/ppieces/utils/prompts.py
+++ b/ppieces/utils/prompts.py
@@ -27,7 +27,7 @@ def welcome():
 
 
 def bye():
-    msg: str = colored("\nAll set! Happy coding!\n", "blue", attrs=["bold"])
+    msg: str = colored("\nAll set! Happy coding!\n", "green", attrs=["bold"])
     print(msg)
 
 

--- a/ppieces/utils/validation.py
+++ b/ppieces/utils/validation.py
@@ -1,7 +1,11 @@
 import os
 import re
+import subprocess
 
+from rich.console import Console
 from termcolor import colored
+
+console = Console()
 
 
 def validate_projects_folder_path(projects_folder_path):
@@ -61,3 +65,95 @@ def validate_project_name(project_path):
     if msg:
         print(msg)
         exit(1)
+
+
+def validate_options(
+    non_interactive,
+    project_folder,
+    project_name,
+    virtual_env,
+    git,
+    pre_commit,
+    ruff,
+    autoenv,
+    makefile,
+    pip_tools,
+    username,
+):
+    valid = True
+
+    if pre_commit:
+        if not git:
+            msg = colored(
+                (
+                    "\nERROR: No point in installing pre-commit without git. "
+                    "Please enable the git option if you want to use pre-commit"
+                ),
+                "red",
+                attrs=["bold"],
+            )
+            print(msg)
+            valid = False
+
+        try:
+            with console.status("[green]Checking if pre-commit is installed..."):
+                subprocess.run(
+                    ["pre-commit", "--version"],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+        except Exception:
+            msg = colored(
+                (
+                    "\nWARNING: pre-commit is not installed. Please make sure to install "
+                    "it\n\tpipx install pre-commit or brew install pre-commit"
+                ),
+                "yellow",
+                attrs=["bold"],
+            )
+            print(msg)
+
+            msg = colored(
+                ("Continuing without pre-commit. You can install it later.\n"),
+                "blue",
+                attrs=["bold"],
+            )
+            print(msg)
+            valid = False
+
+    if pip_tools and not virtual_env:
+        msg = colored(
+            (
+                "\nERROR: You shouldn't use pip-tools without a virtual environment. "
+                "Please enable the virtual environment option."
+            ),
+            "red",
+            attrs=["bold"],
+        )
+        print(msg)
+        valid = False
+
+    if autoenv and not virtual_env:
+        msg = colored(
+            (
+                "\nERROR: No point in setting autoenv without a virtual "
+                "environment. Please enable the virtual environment option."
+            ),
+            "red",
+            attrs=["bold"],
+        )
+        print(msg)
+        valid = False
+
+    if non_interactive and (not project_name or not project_folder):
+        msg = colored(
+            "\nERROR: Both project name and project folder must be provided when running "
+            "in non-interactive mode.\n",
+            "red",
+            attrs=["bold"],
+        )
+        print(msg)
+        valid = False
+
+    return valid


### PR DESCRIPTION
Closes #21 

This PR introduces the `pip-tools` option 

If given, the project created will have a few extra make commands for building and syncing requirements and there will be a `requirements` folder with a few default requirements files (`base.in`, `development.in`, `production.in` and `test.in`) from where to generate the actual `requirements.txt` via `pip-compile`

I also refactored the validation of the given options in its own method.

I modified some of the letters used in options.